### PR TITLE
Remove return_val and make wrapper method to calculate score

### DIFF
--- a/src/FeatureSelector.jl
+++ b/src/FeatureSelector.jl
@@ -26,7 +26,8 @@ export
     f_test,
     chisq_test,
     # Utils
-    one_hot_encode
+    one_hot_encode,
+    calculate_feature_importance
 
 #! format: on
 end # module

--- a/src/UnivariateFeatureSelector.jl
+++ b/src/UnivariateFeatureSelector.jl
@@ -37,14 +37,11 @@ end
     select_features(selector,
                     X::DataFrame,
                     y::Vector;
-                    verbose::Bool=false,
-                    return_val::Bool=false)
+                    verbose::Bool=false)
 
 Select features based on the importance, which is defined by `selector.method`
 to target `y`. if `verbose` is true, logs will be printed - this defaults to
-false. If `return_val` is false, this function will return only the feature
-feature names, otherwise, tuple of selected feature names and the
-correlation value are returned.
+false. This function will return only the feature names of selected features.
 
 If you have feature `X_data` as matrix and feature names `X_features` as a
 Vector, you can replace `X` with `X_data` and `X_features` (in this order).
@@ -79,7 +76,6 @@ function select_features(
     X_features::Vector,
     y::Vector;
     verbose::Bool = false,
-    return_val::Bool = false,
 )
     score_arr = selector.method(X_data, y)
     # Correlation should be sorted descending
@@ -110,11 +106,7 @@ function select_features(
         verbose && @info "Filtering by threshold" selector.threshold
         sorted_tup = filter(v -> filter_operator(abs(v[2]), selector.threshold), sorted_tup)
     end
-    if return_val
-        sorted_tup
-    else
-        first.(sorted_tup)
-    end
+    first.(sorted_tup)
 end
 
 select_features(
@@ -122,14 +114,12 @@ select_features(
     X::DataFrame,
     y::Vector;
     verbose::Bool = false,
-    return_val::Bool = false,
 ) = select_features(
     selector,
     convert(Matrix, X),
     names(X),
     y;
     verbose = verbose,
-    return_val = return_val,
 )
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,3 +58,33 @@ function one_hot_encode(
     end
     result_df
 end
+
+
+"""
+    calculate_feature_importance(method::Function, X::DataFrame, y::Vector)
+
+Calculate feature importance defined by `method`. Similar with `select_features`, this can
+take `X` in `DataFrame` or splitted into `X_data` in `Matrix` and `X_features` in `Vector`.
+
+This function will return `Dict` with feature names as key and scores as value.
+"""
+function calculate_feature_importance(
+    method::Function,
+    X_data::Matrix,
+    X_features::Vector,
+    y::Vector
+)
+    scores = method(X_data, y)
+    Dict(feature_name=>score for (feature_name,score) in zip(X_features, scores))
+end
+
+calculate_feature_importance(
+    method::Function,
+    X::DataFrame,
+    y::Vector
+) = calculate_feature_importance(
+    method,
+    convert(Matrix, X),
+    names(X),
+    y,
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,5 @@ using RDatasets
 @testset "FeatureSelector.jl" begin
     @testset "Univariate feature selector" begin
         include("UnivariateFeatureSelector.jl")
-        # include("PValueBasedFeatureSelector.jl")
     end
 end


### PR DESCRIPTION
Remove `return_val` option in `select_features` for consistency reason. To replace this, `calculate_feature_importance` utility function is provided.